### PR TITLE
se vuelve a dejar configuracion inicial de target en vite.config.js

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,8 +2,8 @@ export default {
   server: {
     proxy: {
       '/api': {
-        // target: 'http://localhost:3000', // Cambia el puerto si es necesario
-        target: 'https://proyecto-7.onrender.com',
+        target: 'http://localhost:3000', // Cambia el puerto si es necesario
+        // target: 'https://proyecto-7.onrender.com',
         changeOrigin: true,
         // rewrite: (path) => path.replace(/^\/api/, ''),
       },


### PR DESCRIPTION
no funcionó la config para RENDER